### PR TITLE
weensyos: use alt. compiler toolchain in arm containers

### DIFF
--- a/weensyos/build/findccprefix.sh
+++ b/weensyos/build/findccprefix.sh
@@ -1,0 +1,5 @@
+#! /bin/sh
+
+# Add prefix 'x86_64-linux-gnu-' in ARM; leave prefix blank in x86.
+
+uname -m | grep "arm\|aarch64" >/dev/null && echo "x86_64-linux-gnu-" || echo ""

--- a/weensyos/build/rules.mk
+++ b/weensyos/build/rules.mk
@@ -3,7 +3,7 @@ comma = ,
 export LC_ALL = C
 
 # Compiler toolchain
-CCPREFIX ?=
+CCPREFIX := $(shell build/findccprefix.sh)
 
 ifeq ($(CCPREFIX),)
 ifeq ($(origin CC),default)
@@ -14,7 +14,7 @@ CXX     := $(shell build/findgcc.sh $(CXX))
 endif
 else
 CC      = $(CCPREFIX)cc
-CXX     = $(CCPREFIX)c++
+CXX     = $(CCPREFIX)g++-9
 endif
 LD      = $(CCPREFIX)ld
 OBJCOPY = $(CCPREFIX)objcopy


### PR DESCRIPTION
When running in an arm environment, look for cross-compilation build
tools. It's assumed cross-compilation dependencies have been installed.

This commit does not change build tool discovery logic when running
in an x86 environment.